### PR TITLE
make the attribute filed more flexible to accept scope and other hash…

### DIFF
--- a/lib/spree/permissions.rb
+++ b/lib/spree/permissions.rb
@@ -51,16 +51,16 @@ module Spree
     end
 
     private
-      def find_action_and_subject(name)
-        can, action, subject, attribute = name.to_s.split('-')
- 
-        if subject == 'all'
-          return can.to_sym, action.to_sym, subject.to_sym, attribute.try(:to_sym)
-        elsif (subject_class = subject.classify.safe_constantize) && subject_class.ancestors.include?(ActiveRecord::Base)
-          return can.to_sym, action.to_sym, subject_class, attribute.try(:to_sym)
-        else
-          return can.to_sym, action.to_sym, subject, attribute.try(:to_sym)
-        end
+    def find_action_and_subject(name)
+      can, action, subject, attribute = name.to_s.split('-')
+      attribute_eval = attribute.blank? ? nil : eval(attribute)
+      if subject == 'all'
+        return can.to_sym, action.to_sym, subject.to_sym, attribute_eval
+      elsif (subject_class = subject.classify.safe_constantize) && subject_class.ancestors.include?(ActiveRecord::Base)
+        return can.to_sym, action.to_sym, subject_class, attribute_eval
+      else
+        return can.to_sym, action.to_sym, subject, attribute_eval
       end
+    end
   end
 end


### PR DESCRIPTION
… options

The attribute section can be made flexible to handle other hash options like scope etc. In order to do it, it can be not be symbol only, so changed it to use eval() function. The original attribute still work fine, and can support Array for multiple attributes as well.