### PR TITLE
The permissions should work predictably irrespective of the sequence of role assignment.

### DIFF
--- a/app/models/spree/ability_decorator.rb
+++ b/app/models/spree/ability_decorator.rb
@@ -13,9 +13,7 @@ module Spree
 
       user ||= Spree.user_class.new
 
-      user_roles(user).each do |role|
-        ability(role, user)
-      end
+      user_roles(user).map(&:permissions).flatten.uniq.map { |permission| permission.ability(self, user) }
 
       Ability.abilities.each do |clazz|
         ability = clazz.send(:new, user)
@@ -25,10 +23,6 @@ module Spree
 
     def user_roles(user)
       (roles = user.roles.includes(:permissions)).empty? ? Spree::Role.default_role.includes(:permissions) : roles
-    end
-
-    def ability(role, user)
-      role.ability(self, user)
     end
   end
 end

--- a/app/models/spree/role_decorator.rb
+++ b/app/models/spree/role_decorator.rb
@@ -10,12 +10,6 @@ Spree::Role.class_eval do
   validates :name, uniqueness: true, allow_blank: true
   validates :permission_sets, length: { minimum: 1, too_short: Spree.t(:atleast_one_permission_set_is_required) }, on: :update
 
-  def ability(current_ability, user)
-    permissions.each do |permission|
-      permission.ability(current_ability, user)
-    end
-  end
-
   def has_permission?(permission_title)
     permissions.pluck(:title).include?(permission_title)
   end

--- a/spec/controllers/spree/admin/roles_controller_spec.rb
+++ b/spec/controllers/spree/admin/roles_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Spree::Admin::RolesController, type: :controller do
     allow(controller).to receive(:spree_current_user).and_return(user)
     allow(user).to receive(:generate_spree_api_key!).and_return(true)
     allow(roles).to receive(:includes).and_return(roles)
-    allow(role).to receive(:ability).and_return(true)
+    allow(role).to receive(:permissions).and_return([])
 
     ability.can :manage, :all
     allow(controller).to receive(:current_ability).and_return(ability)

--- a/spec/models/spree/ability_decorator_spec.rb
+++ b/spec/models/spree/ability_decorator_spec.rb
@@ -344,11 +344,6 @@ RSpec.describe Spree::Ability, type: :model do
       Spree::Ability.new(user)
     end
 
-    it 'should receive ability with role and user' do
-      expect_any_instance_of(Spree::Ability).to receive(:ability).with(role, user).and_call_original
-      Spree::Ability.new(user)
-    end
-
     it 'should receive abilities on Spree::Ability' do
       expect(Spree::Ability).to receive(:abilities).and_call_original
       Spree::Ability.new(user)
@@ -368,15 +363,6 @@ RSpec.describe Spree::Ability, type: :model do
       it { expect(subject).to be_able_to :update, Spree::User.new }
       it { expect(subject).to_not be_able_to :create, Spree::User.new, :role_ids }
       it { expect(subject).to_not be_able_to :update, Spree::User.new, :role_ids }
-    end
-  end
-
-  describe 'ability method' do
-    let(:ability) { Spree::Ability.new(user) }
-
-    it 'should receive ability on role with ability, user' do
-      expect(role).to receive(:ability).with(ability, user).and_return(true)
-      ability.ability(role, user)
     end
   end
 

--- a/spec/models/spree/role_decorator_spec.rb
+++ b/spec/models/spree/role_decorator_spec.rb
@@ -62,20 +62,4 @@ RSpec.describe Spree::Role, type: :model  do
     end
   end
 
-  describe 'ability' do
-    before(:each) do
-      @permissions = [permission1, permission2]
-      allow(role1).to receive(:permissions).and_return(@permissions)
-    end
-
-    it 'should receive permissions and return @permissions' do
-      expect(role1).to receive(:permissions).and_return(@permissions)
-      role1.ability(ability, user)
-    end
-
-    it 'should receive ability on permission' do
-      expect(permission1).to receive(:ability).with(ability, user).and_return(true)
-      role1.ability(ability, user)
-    end
-  end
 end

--- a/spree_admin_roles_and_access.gemspec
+++ b/spree_admin_roles_and_access.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
   s.files = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*']
 
-  s.author    = ["Nishant 'CyRo' Tuteja", "Akhil Bansal", "Nimish Mehta", "Anurag Jain"]
+  s.author    = ["Nishant 'CyRo' Tuteja", "Akhil Bansal", "Nimish Mehta"]
   s.email     = 'info@vinsol.com'
   s.homepage  = 'http://vinsol.com'
 

--- a/spree_admin_roles_and_access.gemspec
+++ b/spree_admin_roles_and_access.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
   s.files = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*']
 
-  s.author    = ["Nishant 'CyRo' Tuteja", "Akhil Bansal", "Nimish Mehta"]
+  s.author    = ["Nishant 'CyRo' Tuteja", "Akhil Bansal", "Nimish Mehta", "Anurag Jain"]
   s.email     = 'info@vinsol.com'
   s.homepage  = 'http://vinsol.com'
 


### PR DESCRIPTION
## The Problem

Consider a scenario where we have two roles let's say a super admin (can manage all) and a safe admin ( superedmin which can not manage some model )

Now, due to the below snippet, the **relative sequence of cancan rules seems to affect the effective authorization rules** since cancan assumes the rules appearing below to have higher priority ( overrides any contrasting rules )

```rb
user_roles(user).each do |role|       
    ability(role, user)
end
```

Please refer the attached detailed comparison showing how the cancan rules are impacted due to this.

[spree_admin_roles_and_access_bug.html.zip](https://github.com/vinsol-spree-contrib/spree_admin_roles_and_access/files/1168798/spree_admin_roles_and_access_bug.html.zip)

---

## Proposed Fix ( In this PR )

We can invoke the cancan rules directly from the `Spree::Permission` so that the rules are mapped based on the priority for each permission and remains independent of the sequence in which a role is assigned to a user.